### PR TITLE
feat(migration): migrate wiki-repositories

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,6 +100,11 @@ platform :ios do
 
     Helper.log.info("Gitlab project has been migrated, now migrate the repository")
     migrate_git_repository(from_repo_url: project.ssh_url_to_repo, to_repo_url: new_project.ssh_url_to_repo)
+
+    if project.wiki_enabled
+      Helper.log.info("Migrating wiki-repository")
+      migrate_git_repository(from_repo_url: project.ssh_url_to_repo.gsub('.git', '.wiki.git'), to_repo_url: new_project.ssh_url_to_repo.gsub('.git', '.wiki.git'))
+    end
   end
 
   # You can define as many lanes as you want


### PR DESCRIPTION
Wiki-migration was originally not implemented because the gitlab API does not return the wiki-repo url for a project. 

However, gitlab seems to just use the normal repo url with `.wiki` appended for the wiki repo. 
So for a repository `git@gitlab.example.com:group/my-repo.git`, the wiki repo has the url `git@gitlab.example.com:group/my-repo.wiki.git`.

I have also tested and confirmed that changing the repo-url for an existing project also changes the wiki url accordingly, so this should be save (until gitlab changes this :speak_no_evil: )

Fixes #3, thanks @chraibi for the idea :sparkles: 
