### PR TITLE
Migrate snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,21 @@ I've put this into my `~/.zshrc` (because I did not find out how else to set thi
 * labels
 * notes (see caveats)
 
+### Snippets
+
+* project
+* name
+* filename
+* code
+* notes (see caveats)
+* ❗️author is not migrated
+  * author of the new snippet is the user thats performing the migration
+* ❗️visibility level is not migrated
+  * snippets will be created with visibility level = 'internal'
+
 ## Whats not being migrated
 
 * Merge Requests + Notes
-* Snippets + Notes
 * System Hooks
 * Users
 


### PR DESCRIPTION
This implements the migration of snippets (see #10 )

Migrating snippets has two caveats:

* The original `author` is not migrated 
  * Gitlab-API does not seem to offer a request to assign an author when creating/updating a snippet
  * Author of the migrated issue is the user performing the migration
* `visibility_level` is not migrated
  * Gitlab-API does not seem to include the `visibility_level` in responses when requesting snippets
  * Migrated issues are automatically created with visibility level `internal`